### PR TITLE
added fix in sortBy column to set page back to 1

### DIFF
--- a/src/components/TableContent/table-content.tsx
+++ b/src/components/TableContent/table-content.tsx
@@ -77,8 +77,10 @@ export const TableContent: React.FC<TableContentProps> = ({
       setSortDirection(sortDirection === "asc" ? "desc" : "asc");
     } else {
       setSortBy(column);
+
       setSortDirection("asc");
     }
+    setPage(1);
   };
 
   if (isLoading) {


### PR DESCRIPTION
Late push, just updated the sorting on the category filter when clicked. Just resets the page back to 1
